### PR TITLE
INF-112: add default timeout in get request

### DIFF
--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -62,7 +62,8 @@ class GorgiasAPI:
         resp = requests.post(
             url,
             json=params,
-            auth=(self.username, self.password)
+            auth=(self.username, self.password),
+            timeout=DEFAULT_TIMEOUT
         )
 
         return resp.json()

--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -1,12 +1,14 @@
 import json
 import requests
 import requests.exceptions
+import os
 import singer
 import time
 import urllib
 
 LOGGER = singer.get_logger()
 
+DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT')
 
 class GorgiasAPI:
     URL_TEMPLATE = 'https://{}.gorgias.com'
@@ -23,10 +25,11 @@ class GorgiasAPI:
             url = f'{self.base_url}{url}'
 
         for num_retries in range(self.MAX_RETRIES):
-            LOGGER.info(f'gorgias get request {url}')
+            LOGGER.info(f'gorgias get request {url}, timeout={DEFAULT_TIMEOUT}')
             resp = requests.get(
                 url,
-                auth=(self.username, self.password)
+                auth=(self.username, self.password),
+                timeout=DEFAULT_TIMEOUT
             )
             try:
                 resp.raise_for_status()


### PR DESCRIPTION
Uses environment variable 'DEFAULT_HTTP_TIMEOUT' as defined in the Dockerfile for lloyd (https://github.com/Pathlight/lloyd/pull/68).

Tested by running tap locally using tap config for 4patriots and hard coding timeout to be 10.

https://user-images.githubusercontent.com/29642644/191630280-a6ef0a1c-7386-498e-9c41-dc4e00d526f0.mov

Error produced when request times out (this would cause a failed tap run):
<img width="1031" alt="Screen Shot 2022-09-21 at 5 02 59 PM" src="https://user-images.githubusercontent.com/29642644/191630594-90402dfa-40ef-4f94-8a70-8042c3c4fc4b.png">

