### PR TITLE
INF-112: Cast environment variable to int before passing in as parameter

### DIFF
--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -8,7 +8,11 @@ import urllib
 
 LOGGER = singer.get_logger()
 
-DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT') and int(os.getenv('DEFAULT_HTTP_TIMEOUT'))
+timeout = os.getenv('DEFAULT_HTTP_TIMEOUT')
+try:
+    DEFAULT_TIMEOUT = int(timeout) if timeout else None
+except (TypeError, ValueError):
+    DEFAULT_TIMEOUT = None
 
 class GorgiasAPI:
     URL_TEMPLATE = 'https://{}.gorgias.com'

--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -8,7 +8,7 @@ import urllib
 
 LOGGER = singer.get_logger()
 
-DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT')
+DEFAULT_TIMEOUT = os.getenv('DEFAULT_HTTP_TIMEOUT') and int(os.getenv('DEFAULT_HTTP_TIMEOUT'))
 
 class GorgiasAPI:
     URL_TEMPLATE = 'https://{}.gorgias.com'


### PR DESCRIPTION
Follow-up from: https://github.com/Pathlight/tap-gorgias/pull/4

Environment variables are stored as strings. As such, when we retrieve the default timeout environment variable, it is a string (or None if the var is not defined). Previously, we were passing the string in directly as the timeout param in the http requests. This resulted in type error (see screenshot below) within the tap.

This PR casts the timeout as an int prior to passing it in as a parameter to the http requests.

<img width="1252" alt="Screen Shot 2022-09-27 at 9 50 15 AM" src="https://user-images.githubusercontent.com/29642644/192602166-50f47b9a-e2d7-4c22-94e0-77040528146e.png">

