### PR TITLE
Update streams to not use deprecated APIs and use their cursors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,11 +94,11 @@ ENV/
 
 # Custom stuff
 env.sh
-config.json
-catalog.json
+config*.json
+catalog*.json
+state*.json
 .autoenv.zsh
 
 rsa-key
 tags
 singer-check-tap-data
-state.json

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-gorgias",
-    version="0.1.8",
+    version="0.1.9",
     description="Singer.io tap for extracting data from the Gorgias API",
     author="Pathlight",
     url="https://www.pathlight.com/",

--- a/tap_gorgias/__init__.py
+++ b/tap_gorgias/__init__.py
@@ -12,9 +12,7 @@ from .sync import sync_stream
 
 
 REQUIRED_CONFIG_KEYS = ["subdomain", "username", "password", "start_date"]
-SUB_STREAMS = {
-    # 'tickets': ['messages']
-}
+SUB_STREAMS = {}
 LOGGER = singer.get_logger()
 
 

--- a/tap_gorgias/__init__.py
+++ b/tap_gorgias/__init__.py
@@ -13,7 +13,7 @@ from .sync import sync_stream
 
 REQUIRED_CONFIG_KEYS = ["subdomain", "username", "password", "start_date"]
 SUB_STREAMS = {
-    'tickets': ['messages']
+    # 'tickets': ['messages']
 }
 LOGGER = singer.get_logger()
 

--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -24,7 +24,7 @@ class GorgiasAPI:
         self.subdomain = config['subdomain']
         self.base_url = self.URL_TEMPLATE.format(self.subdomain)
 
-    def get(self, url):
+    def get(self, url, make_log_on_request: bool=True):
         if not url:
             LOGGER.info(f'gorgias get request attempted, but no url passed through')
             return {}
@@ -33,7 +33,8 @@ class GorgiasAPI:
             url = f'{self.base_url}{url}'
 
         for num_retries in range(self.MAX_RETRIES):
-            LOGGER.info(f'gorgias get request {url}, timeout={DEFAULT_TIMEOUT}')
+            if make_log_on_request:
+                LOGGER.info(f'gorgias get request {url}, timeout={DEFAULT_TIMEOUT}')
             resp = requests.get(
                 url,
                 auth=(self.username, self.password),

--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -4,7 +4,8 @@ import requests.exceptions
 import os
 import singer
 import time
-import urllib
+from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, unquote
+from typing import Any, Dict
 
 LOGGER = singer.get_logger()
 
@@ -13,6 +14,18 @@ try:
     DEFAULT_TIMEOUT = int(timeout) if timeout else None
 except (TypeError, ValueError):
     DEFAULT_TIMEOUT = None
+
+def add_url_params(url: str, query_params: Dict[str, Any]) -> str:
+    # Handle urls that already have query params and merge them together with other query_params
+    parsed_url = urlparse(unquote(url))
+    existing_get_args = parse_qs(parsed_url.query)
+    existing_get_args.update(query_params)
+    merged_url_encoded_get_args = urlencode(existing_get_args, doseq=True)
+    # Unquote the url to preserve previous behaviour
+    return unquote(ParseResult(
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+        parsed_url.params, merged_url_encoded_get_args, parsed_url.fragment
+    ).geturl())
 
 class GorgiasAPI:
     URL_TEMPLATE = 'https://{}.gorgias.com'

--- a/tap_gorgias/client.py
+++ b/tap_gorgias/client.py
@@ -41,6 +41,7 @@ class GorgiasAPI:
                 timeout=DEFAULT_TIMEOUT
             )
             try:
+                # https://developers.gorgias.com/reference/limitations
                 resp.raise_for_status()
             except requests.exceptions.RequestException:
                 if resp.status_code == 429 and num_retries < self.MAX_RETRIES:

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -239,8 +239,8 @@ class Events(CursorStream):
         # https://developers.gorgias.com/reference/get_api-events
 
         sync_thru, max_synced_thru = self.get_sync_thru_dates(state)
-        # events are ordered in ascending order since we include an order_by query param
-        # explicitly limit the time to utcnow
+        # events are ordered in ascending order since we have both order_by and datetime 
+        # query params, explicitly limit the time to utcnow
         query_params = {
             'limit': 100,
             'order_by': 'created_datetime:asc',

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -143,11 +143,11 @@ class Tickets(CursorStream):
         }
         LOGGER.info(f'Starting fetch for {self.name} stopping at {sync_thru}')
         for row in self.cursor_get(self.url, query_params):
-            message = {k: self.transform_value(k, v) for (k, v) in row.items()}
-            curr_synced_thru: str = message[self.replication_key]
+            ticket = {k: self.transform_value(k, v) for (k, v) in row.items()}
+            curr_synced_thru: str = ticket[self.replication_key]
             max_synced_thru = max(curr_synced_thru, max_synced_thru)
             if curr_synced_thru > sync_thru:
-                yield(self.stream, message)
+                yield(self.stream, ticket)
             else:
                 break
 
@@ -213,11 +213,11 @@ class SatisfactionSurveys(CursorStream):
         }
         LOGGER.info(f'Starting fetch for {self.name} stopping at {sync_thru}')
         for row in self.cursor_get(self.url, query_params):
-            message = {k: self.transform_value(k, v) for (k, v) in row.items()}
-            curr_synced_thru: str = message[self.replication_key]
+            survey = {k: self.transform_value(k, v) for (k, v) in row.items()}
+            curr_synced_thru: str = survey[self.replication_key]
             max_synced_thru = max(curr_synced_thru, max_synced_thru)
             if curr_synced_thru > sync_thru:
-                yield(self.stream, message)
+                yield(self.stream, survey)
             else:
                 break
 

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -158,7 +158,7 @@ class Messages(CursorStream):
     name = 'messages'
     replication_method = 'INCREMENTAL'
     key_properties = ['id']
-    replication_key = 'sent_datetime'
+    replication_key = 'created_datetime'
     url = '/api/messages'
     datetime_fields = set([
         'created_datetime', 'sent_datetime', 'failed_datetime',

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -248,6 +248,8 @@ class Events(CursorStream):
     results_key = 'data'    
 
     def sync(self, state, config):
+        # https://developers.gorgias.com/reference/get_api-events
+
         sync_thru, max_synced_thru = self.get_sync_thru_dates(state)
         # events are ordered in ascending order since we include an order_by query param
         # explicitly limit the time to utcnow


### PR DESCRIPTION
Jira key: https://pathlighthq.atlassian.net/browse/INF-436

As an investigative process on figuring out long runtimes:
1. Use the same transformed datetime value format. The comparisons might be incorrect since we're doing string comparisons and one might be a date, one might datetime, one might timezone aware, another one isn't, etc. Keep it all consistent
2. Use `api/messages` instead of `api/tickets/{ticket_id}/messages` since it is [deprecated](https://developers.gorgias.com/reference/get_api-tickets-ticket-id-messages). We get rate limited quite quickly because we're requesting messages for every ticket instead of getting just the messages, and as a result, we're spending a lot of time waiting. This is probably the largest impact in resolving long runtimes. As a comparison, I ran the following **non-concurrently** (it's not super exhaustive but there are gains):
  - for the last 4 hours of data for all streams:
    - with the previous code, the runtime is 3:47, ~10k singer records, 100 rate limit responses
    - with this branch, the runtime is 1:24 ~ 9.5k singer records, 37 rate limit responses - less than half the time and rate limit responses
  - for the last 24 hours of data for all streams:
    - with the previous code, the runtime is 11:16 ~36k singer records, 286 rate limit responses
    - with this branch, the runtime is 6:08, ~35k singer records, 128 rate limit responses - about half in time and rate limit responses
3. Whenever the sync for events is started, include an explicit end date using the time the sync starts. Gorgias doesn't explicitly say that we can get more events when the requests are made, so let us explicitly define it.


